### PR TITLE
Add `Builder.output` APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and `Rust` [Command][url-rust-command]
 ## Example
 
 ```kotlin
-val b = Process.Builder(command = "cat")
+val builder = Process.Builder(command = "cat")
     // Optional arguments
     .args("--show-ends")
     // Also accepts vararg and List<String>
@@ -61,11 +61,14 @@ val b = Process.Builder(command = "cat")
     // variable
     .environment("HOME", myApplicationDir.path)
 
-// Spawn the process
-b.spawn().let { p ->
+// Spawned process
+builder.spawn().let { p ->
 
     try {
-        // Blocking APIs (Jvm & Native)
+        // Blocking APIs (Jvm & Native).
+        //
+        // Alternatively, waitForAsync is available for all
+        // platforms
         val code: Int? = p.waitFor(250.milliseconds)
 
         if (code == null) {
@@ -77,7 +80,13 @@ b.spawn().let { p ->
     }
 }
 
-// TODO: output example
+// Direct output
+builder.output { timeoutMillis = 500 }.let { output ->
+    println(output.stdout)
+    println(output.stderr)
+    println(output.processError ?: "no errors")
+    println(output.processInfo)
+}
 ```
 
 ## Get Started

--- a/library/process/api/process.api
+++ b/library/process/api/process.api
@@ -1,6 +1,36 @@
 public abstract interface annotation class io/matthewnelson/kmp/process/InternalProcessApi : java/lang/annotation/Annotation {
 }
 
+public final class io/matthewnelson/kmp/process/Output {
+	public final field processError Ljava/lang/String;
+	public final field processInfo Lio/matthewnelson/kmp/process/Output$ProcessInfo;
+	public final field stderr Ljava/lang/String;
+	public final field stdout Ljava/lang/String;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/matthewnelson/kmp/process/Output$ProcessInfo;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/process/Output$Options {
+	public synthetic fun <init> (IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/matthewnelson/kmp/process/Output$Options$Builder {
+	public field maxBuffer I
+	public field timeoutMillis I
+}
+
+public final class io/matthewnelson/kmp/process/Output$ProcessInfo {
+	public final field args Ljava/util/List;
+	public final field command Ljava/lang/String;
+	public final field destroySignal Lio/matthewnelson/kmp/process/Signal;
+	public final field environment Ljava/util/Map;
+	public final field exitCode I
+	public final field pid I
+	public final field stdio Lio/matthewnelson/kmp/process/Stdio$Config;
+	public synthetic fun <init> (IILjava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/matthewnelson/kmp/process/Stdio$Config;Lio/matthewnelson/kmp/process/Signal;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class io/matthewnelson/kmp/process/Process {
 	public final field args Ljava/util/List;
 	public final field command Ljava/lang/String;
@@ -28,6 +58,8 @@ public final class io/matthewnelson/kmp/process/Process$Builder {
 	public final fun destroySignal (Lio/matthewnelson/kmp/process/Signal;)Lio/matthewnelson/kmp/process/Process$Builder;
 	public final fun environment (Ljava/lang/String;Ljava/lang/String;)Lio/matthewnelson/kmp/process/Process$Builder;
 	public final fun environment (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/kmp/process/Process$Builder;
+	public final fun output ()Lio/matthewnelson/kmp/process/Output;
+	public final fun output (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/kmp/process/Output;
 	public final fun spawn ()Lio/matthewnelson/kmp/process/Process;
 	public final fun stderr (Lio/matthewnelson/kmp/process/Stdio;)Lio/matthewnelson/kmp/process/Process$Builder;
 	public final fun stdin (Lio/matthewnelson/kmp/process/Stdio;)Lio/matthewnelson/kmp/process/Process$Builder;

--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Output.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Output.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.process
+
+import io.matthewnelson.kmp.process.internal.appendProcessInfo
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmSynthetic
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Output results from [Process.Builder.output]
+ * */
+public class Output private constructor(
+
+    /**
+     * The contents of [Process] `stdout` output
+     * */
+    @JvmField
+    public val stdout: String,
+
+    /**
+     * The contents of [Process] `stderr` output
+     * */
+    @JvmField
+    public val stderr: String,
+
+    /**
+     * If an error occurred with the [Process], such as
+     * the [Options.maxBuffer] or [Options.timeout] was
+     * exceeded.
+     * */
+    @JvmField
+    public val processError: String?,
+
+    /**
+     * Information about the [Process] that ran.
+     * */
+    @JvmField
+    public val processInfo: ProcessInfo,
+) {
+
+    /**
+     * Options for [Process.Builder.output]
+     *
+     * @see [Builder]
+     * */
+    public class Options private constructor(
+//        internal val input: String?,
+        internal val maxBuffer: Int,
+        internal val timeout: Duration,
+    ) {
+
+        public class Builder private constructor() {
+
+            // TODO: Need to think on this. May want to use
+            //  a Buffer or some dedicated input class.
+            //@JvmField
+//            private var input: String? = null
+
+            /**
+             * Maximum number of bytes that can be buffered
+             * on `stdout` or `stderr`. If exceeded, [Process]
+             * will be terminated and output truncated.
+             *
+             * Default: 2147483647 / 2
+             * Minimum: 1024 * 16
+             * */
+            @JvmField
+            public var maxBuffer: Int = Int.MAX_VALUE / 2
+
+            /**
+             * Maximum number of milliseconds the [Process] is
+             * allowed to run. If exceeded, [Process] will be
+             * terminated.
+             *
+             * Default: 250
+             * Minimum: 250
+             * */
+            @JvmField
+            public var timeoutMillis: Int = MIN_TIMEOUT
+
+            internal companion object {
+
+                private const val MIN_TIMEOUT: Int = 250
+                private const val MIN_BUFFER: Int = 1024 * 16
+
+                @JvmSynthetic
+                internal fun build(
+                    block: Builder.() -> Unit,
+                ): Options {
+                    val b = Builder().apply(block)
+
+                    val maxBuffer = b.maxBuffer.let { max ->
+                        if (max < MIN_BUFFER) MIN_BUFFER else max
+                    }
+                    val timeout = b.timeoutMillis.let { millis ->
+                        (if (millis < MIN_TIMEOUT) MIN_TIMEOUT else millis)
+                    }
+
+                    return Options(/*b.input, */maxBuffer, timeout.milliseconds)
+                }
+            }
+        }
+    }
+
+    /**
+     * Information about the [Process] that ran in order
+     * to produce [Output].
+     * */
+    public class ProcessInfo private constructor(
+        @JvmField
+        public val pid: Int,
+        @JvmField
+        public val exitCode: Int,
+        @JvmField
+        public val command: String,
+        @JvmField
+        public val args: List<String>,
+        @JvmField
+        public val environment: Map<String, String>,
+        @JvmField
+        public val stdio: Stdio.Config,
+        @JvmField
+        public val destroySignal: Signal,
+    ) {
+
+        internal companion object {
+
+            @JvmSynthetic
+            internal fun createOutput(
+                stdout: String,
+                stderr: String,
+                processError: String?,
+                pid: Int,
+                exitCode: Int,
+                command: String,
+                args: List<String>,
+                environment: Map<String, String>,
+                stdio: Stdio.Config,
+                destroySignal: Signal,
+            ): Output = Output(
+                stdout,
+                stderr,
+                processError,
+                ProcessInfo(
+                    pid,
+                    exitCode,
+                    command,
+                    args,
+                    environment,
+                    stdio,
+                    destroySignal,
+                )
+            )
+        }
+
+        override fun toString(): String = buildString {
+            appendProcessInfo(
+                "Output.ProcessInfo",
+                pid,
+                exitCode.toString(),
+                command,
+                args,
+                stdio,
+                destroySignal
+            )
+        }
+    }
+
+    override fun toString(): String = buildString {
+        appendLine("Output: [")
+        appendLine("    stdout: [Omitted]")
+        appendLine("    stderr: [Omitted]")
+        append("    processError: ")
+        appendLine(processError)
+
+        processInfo.toString().lines().let { lines ->
+            appendLine("    processInfo: [")
+            for (i in 1 until lines.size) {
+                append("    ")
+                appendLine(lines[i])
+            }
+        }
+
+        append(']')
+    }
+}

--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/-CommonPlatform.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/-CommonPlatform.kt
@@ -16,5 +16,53 @@
 package io.matthewnelson.kmp.process.internal
 
 import io.matthewnelson.kmp.file.File
+import io.matthewnelson.kmp.process.Signal
+import io.matthewnelson.kmp.process.Stdio
 
 internal expect val STDIO_NULL: File
+
+internal fun StringBuilder.appendProcessInfo(
+    className: String,
+    pid: Int,
+    exitCode: String,
+    command: String,
+    args: List<String>,
+    stdio: Stdio.Config,
+    destroySignal: Signal,
+) {
+    append(className)
+    appendLine(": [")
+
+    append("    pid: ")
+    appendLine(pid)
+
+    append("    exitCode: ")
+    appendLine(exitCode)
+
+    append("    command: ")
+    appendLine(command)
+
+    append("    args: [")
+    if (args.isEmpty()) {
+        appendLine(']')
+    } else {
+        args.joinTo(
+            this,
+            separator = "\n        ",
+            prefix = "\n        ",
+            postfix = "\n    ]\n"
+        )
+    }
+
+    appendLine("    stdio: [")
+    stdio.toString().lines().let { lines ->
+        for (i in 1 until lines.size) {
+            append("    ")
+            appendLine(lines[i])
+        }
+    }
+
+    append("    destroySignal: ")
+    appendLine(destroySignal)
+    append(']')
+}

--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -18,6 +18,7 @@
 package io.matthewnelson.kmp.process.internal
 
 import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.process.Output
 import io.matthewnelson.kmp.process.Process
 import io.matthewnelson.kmp.process.Signal
 import io.matthewnelson.kmp.process.Stdio
@@ -27,7 +28,17 @@ internal expect class PlatformBuilder internal constructor() {
     internal val env: MutableMap<String, String>
 
     @Throws(IOException::class)
-    internal fun build(
+    internal fun output(
+        command: String,
+        args: List<String>,
+        env: Map<String, String>,
+        stdio: Stdio.Config,
+        options: Output.Options,
+        destroy: Signal,
+    ): Output
+
+    @Throws(IOException::class)
+    internal fun spawn(
         command: String,
         args: List<String>,
         env: Map<String, String>,

--- a/library/process/src/commonTest/kotlin/io/matthewnelson/kmp/process/ProcessBaseTest.kt
+++ b/library/process/src/commonTest/kotlin/io/matthewnelson/kmp/process/ProcessBaseTest.kt
@@ -199,10 +199,10 @@ abstract class ProcessBaseTest {
     }
 
     @Test
-    fun givenExecutableFile_whenExecuteAsProcess_thenIsSuccessful() = runTest(timeout = 25.seconds) {
+    fun givenExecutableFile_whenExecuteAsProcess_thenIsSuccessful() = runTest(timeout = 45.seconds) {
         val paths = installer.install()
 
-        val p = Process.Builder(paths.tor)
+        val b = Process.Builder(paths.tor)
             .args("--DataDirectory")
             .args(installer.installationDir.resolve("data").path)
             .args("--CacheDirectory")
@@ -227,7 +227,8 @@ abstract class ProcessBaseTest {
             .stderr(Stdio.Inherit)
 //            .stdout(Stdio.File.of(installer.installationDir.resolve("tor.log")))
 //            .stderr(Stdio.File.of(installer.installationDir.resolve("tor.err")))
-            .spawn()
+
+        val p = b.spawn()
 
         destroyOnCompletion(p)
 
@@ -252,6 +253,18 @@ abstract class ProcessBaseTest {
             else -> 0
         }
         assertEquals(expected, p.exitCode())
+
+        if (isNodeJS) {
+            val out = b.output {
+                timeoutMillis = 5_000
+            }
+
+            assertEquals(expected, out.processInfo.exitCode)
+            assertTrue(out.stdout.contains(" [notice] Tor "))
+            assertTrue(out.stderr.isEmpty())
+
+            println(out)
+        }
     }
 
     protected fun TestScope.destroyOnCompletion(p: Process) {

--- a/library/process/src/commonTest/kotlin/io/matthewnelson/kmp/process/ProcessBaseTest.kt
+++ b/library/process/src/commonTest/kotlin/io/matthewnelson/kmp/process/ProcessBaseTest.kt
@@ -254,7 +254,7 @@ abstract class ProcessBaseTest {
         }
         assertEquals(expected, p.exitCode())
 
-        if (isNodeJS) {
+        if (isNodeJS || isJvm) {
             val out = b.output {
                 timeoutMillis = 5_000
             }

--- a/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/JsChildProcess.kt
+++ b/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/JsChildProcess.kt
@@ -29,6 +29,14 @@ internal external fun child_process_spawn(
     options: dynamic,
 ): child_process_ChildProcess
 
+/** [docs](https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options) */
+@JsName("spawnSync")
+internal external fun child_process_spawnSync(
+    command: String,
+    args: Array<String>,
+    options: dynamic,
+): dynamic
+
 /** [docs](https://nodejs.org/api/child_process.html#class-childprocess) */
 @JsName("ChildProcess")
 @OptIn(InternalProcessApi::class)

--- a/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/NodeJsProcess.kt
+++ b/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/NodeJsProcess.kt
@@ -37,6 +37,7 @@ internal class NodeJsProcess internal constructor(
         return this
     }
 
+    // @Throws(IllegalStateException::class)
     override fun exitCode(): Int {
         jsProcess.exitCode?.toInt()?.let { return it }
 
@@ -51,9 +52,21 @@ internal class NodeJsProcess internal constructor(
         throw IllegalStateException("Process hasn't exited")
     }
 
-    override fun pid(): Int = jsProcess.pid?.toInt() ?: -1
+    override fun pid(): Int {
+        val result = try {
+            // can be undefined if called before the
+            // underlying process has not spawned yet.
+            jsProcess.pid?.toInt()
+        } catch (_: Throwable) {
+            null
+        }
 
+        return result ?: -1
+    }
+
+    // @Throws(UnsupportedOperationException::class)
     override fun waitFor(): Int = throw UnsupportedOperationException(WAIT_FOR_ERR)
+    // @Throws(UnsupportedOperationException::class)
     override fun waitFor(duration: Duration): Int = throw UnsupportedOperationException(WAIT_FOR_ERR)
 
     private companion object {

--- a/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -18,6 +18,7 @@
 package io.matthewnelson.kmp.process.internal
 
 import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.process.Output
 import io.matthewnelson.kmp.process.Process
 import io.matthewnelson.kmp.process.Signal
 import io.matthewnelson.kmp.process.Stdio
@@ -31,7 +32,19 @@ internal actual class PlatformBuilder internal actual constructor() {
     }
 
     @Throws(IOException::class)
-    internal actual fun build(
+    internal actual fun output(
+        command: String,
+        args: List<String>,
+        env: Map<String, String>,
+        stdio: Stdio.Config,
+        options: Output.Options,
+        destroy: Signal,
+    ): Output {
+        throw IOException("Not yet implemented")
+    }
+
+    @Throws(IOException::class)
+    internal actual fun spawn(
         command: String,
         args: List<String>,
         env: Map<String, String>,

--- a/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -18,6 +18,7 @@
 package io.matthewnelson.kmp.process.internal
 
 import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.file.InterruptedException
 import io.matthewnelson.kmp.process.Output
 import io.matthewnelson.kmp.process.Process
 import io.matthewnelson.kmp.process.Signal
@@ -40,7 +41,74 @@ internal actual class PlatformBuilder internal actual constructor() {
         options: Output.Options,
         destroy: Signal,
     ): Output {
-        throw IOException("Not yet implemented")
+
+        val (jProcess, process) = spawnJvm(command, args, env, stdio, destroy)
+
+        val result: Output = try {
+            StdioOutputEater.of(
+                maxBuffer = options.maxBuffer,
+                stdout = jProcess.inputStream,
+                stderr = jProcess.errorStream,
+            ).use { eater ->
+
+                var waitForCode: Int? = null
+                try {
+                    waitForCode = process.commonWaitFor(options.timeout) {
+                        if (eater.maxBufferExceeded) {
+                            throw IllegalStateException()
+                        }
+
+                        Thread.sleep(it.inWholeMilliseconds)
+                    }
+                } catch (e: InterruptedException) {
+                    throw IOException("Underlying thread interrupted", e)
+                } catch (e: IllegalStateException) {
+                    // maxBuffer was exceeded and it hopped out of waitFor
+                } finally {
+                    // whether timed out or not, always destroy
+                    // so that streams are closed
+                    process.destroy()
+                }
+
+                val pErr = StringBuilder()
+                if (waitForCode == null) {
+                    pErr.append("waitFor timed out")
+                }
+
+                val exitCode = waitForCode ?: try {
+                    // await for final closure if not ready yet
+                    process.waitFor()
+                } catch (e: InterruptedException) {
+                    throw IOException("Underlying thread interrupted", e)
+                }
+
+                val (stdout, stderr) = eater.doFinal()
+
+                if (eater.maxBufferExceeded) {
+                    if (pErr.isNotEmpty()) {
+                        pErr.append(". ")
+                    }
+                    pErr.append("maxBuffer[${options.maxBuffer}] exceeded")
+                }
+
+                Output.ProcessInfo.createOutput(
+                    stdout,
+                    stderr,
+                    if (pErr.isEmpty()) null else pErr.toString(),
+                    process.pid(),
+                    exitCode,
+                    process.command,
+                    process.args,
+                    process.environment,
+                    process.stdio,
+                    process.destroySignal
+                )
+            }
+        } finally {
+            process.destroy()
+        }
+
+        return result
     }
 
     @Throws(IOException::class)
@@ -50,7 +118,17 @@ internal actual class PlatformBuilder internal actual constructor() {
         env: Map<String, String>,
         stdio: Stdio.Config,
         destroy: Signal,
-    ): Process {
+    ): Process = spawnJvm(command, args, env, stdio, destroy).second
+
+    @Throws(IOException::class)
+    private fun spawnJvm(
+        command: String,
+        args: List<String>,
+        env: Map<String, String>,
+        stdio: Stdio.Config,
+        destroy: Signal,
+    ): Pair<java.lang.Process, JvmProcess> {
+
         val jCommands = ArrayList<String>(args.size + 1)
         jCommands.add(command)
         jCommands.addAll(args)
@@ -72,7 +150,7 @@ internal actual class PlatformBuilder internal actual constructor() {
             } ?: destroy
         }
 
-        return JvmProcess.of(
+        return jProcess to JvmProcess.of(
             jProcess,
             command,
             args,

--- a/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/StdioOutputEater.kt
+++ b/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/StdioOutputEater.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.process.internal
+
+import io.matthewnelson.kmp.file.IOException
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.util.concurrent.Executors
+import kotlin.concurrent.Volatile
+
+internal class StdioOutputEater private constructor(
+    private val maxBuffer: Int,
+    stdout: InputStream,
+    stderr: InputStream,
+): AutoCloseable {
+
+    @Volatile
+    internal var maxBufferExceeded: Boolean = false
+        private set
+
+    private val executors = Executors.newFixedThreadPool(2) {
+        Thread(it).apply { isDaemon = true }
+    }
+
+    private val stdoutBytes = ByteBufferOutputStream()
+    private val stderrBytes = ByteBufferOutputStream()
+
+    init {
+        executors.execute(Eater(stdout, stdoutBytes))
+        executors.execute(Eater(stderr, stderrBytes))
+    }
+
+    internal fun doFinal(): Pair<String, String> {
+        executors.shutdown()
+        return stdoutBytes.toString() to stderrBytes.toString()
+    }
+
+    override fun close() {
+        executors.shutdown()
+        stdoutBytes.close()
+        stderrBytes.close()
+    }
+
+    private inner class Eater(
+        private val output: InputStream,
+        private val buffer: ByteBufferOutputStream,
+    ): Runnable {
+        override fun run() {
+            val buf = ByteArray(4096)
+
+            while (!executors.isShutdown) {
+                var read = try {
+                    output.read(buf)
+                } catch (_: IOException) {
+                    // stream closed
+                    break
+                }
+
+                if (read == -1) break
+
+                val remaining = maxBuffer - buffer.size()
+                var exceeded = false
+
+                if (read > remaining) {
+                    exceeded = true
+                    read = if (remaining < 1) 0 else remaining
+                }
+
+                buffer.write(buf, 0, read)
+
+                if (exceeded) {
+                    maxBufferExceeded = true
+                    break
+                }
+            }
+
+            buf.fill(0)
+        }
+    }
+
+    private class ByteBufferOutputStream: ByteArrayOutputStream(8192) {
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            val oldBuf = buf
+            super.write(b, off, len)
+            if (oldBuf.hashCode() == buf.hashCode()) return
+
+            // clear old buffer before de-referencing if it was re-sized
+            oldBuf.fill(0)
+        }
+
+        override fun close() {
+            buf.fill(0, toIndex = size())
+            reset()
+            super.close()
+        }
+    }
+
+    internal companion object {
+
+        @JvmSynthetic
+        internal fun of(
+            maxBuffer: Int,
+            stdout: InputStream,
+            stderr: InputStream,
+        ) = StdioOutputEater(maxBuffer, stdout, stderr)
+    }
+}

--- a/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -18,6 +18,7 @@
 package io.matthewnelson.kmp.process.internal
 
 import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.process.Output
 import io.matthewnelson.kmp.process.Process
 import io.matthewnelson.kmp.process.Signal
 import io.matthewnelson.kmp.process.Stdio
@@ -34,8 +35,20 @@ internal actual class PlatformBuilder internal actual constructor() {
     }
 
     @Throws(IOException::class)
+    internal actual fun output(
+        command: String,
+        args: List<String>,
+        env: Map<String, String>,
+        stdio: Stdio.Config,
+        options: Output.Options,
+        destroy: Signal,
+    ): Output {
+        throw IOException("Not yet implemented")
+    }
+
+    @Throws(IOException::class)
     @OptIn(ExperimentalForeignApi::class)
-    internal actual fun build(
+    internal actual fun spawn(
         command: String,
         args: List<String>,
         env: Map<String, String>,


### PR DESCRIPTION
Part of #20 

Implements things for `Jvm` and `Node.js`. Tests are a bit haggard. Will clean up in a future PR once the API is settled and Native has an implementation.