### PR TITLE
Clean up `Jvm` implementation

### DIFF
--- a/library/process/build.gradle.kts
+++ b/library/process/build.gradle.kts
@@ -43,7 +43,6 @@ kmpConfiguration {
             with(sourceSets) {
                 val jvmMain = findByName("jvmMain")
                 val nativeMain = findByName("nativeMain")
-
                 if (nativeMain != null || jvmMain != null) {
                     val nonJsMain = maybeCreate("nonJsMain")
                     nonJsMain.dependsOn(getByName("commonMain"))
@@ -58,6 +57,7 @@ kmpConfiguration {
 
                 val linuxMain = findByName("linuxMain")
                 val macosMain = findByName("macosMain")
+//                val androidNative = findByName("androidNativeMain")
                 if (linuxMain != null || macosMain != null) {
                     val forkExecMain = maybeCreate("forkExecMain")
                     forkExecMain.dependsOn(getByName("nativeMain"))
@@ -70,6 +70,7 @@ kmpConfiguration {
                     findByName("macosTest")?.apply { dependsOn(forkExecTest) }
                 }
             }
+
             targets.filterIsInstance<KotlinNativeTarget>().spawnCInterop()
         }
     }

--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Process.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Process.kt
@@ -18,6 +18,7 @@ package io.matthewnelson.kmp.process
 import io.matthewnelson.immutable.collections.toImmutableList
 import io.matthewnelson.immutable.collections.toImmutableMap
 import io.matthewnelson.kmp.file.*
+import io.matthewnelson.kmp.process.internal.SyntheticAccess
 import io.matthewnelson.kmp.process.internal.PlatformBuilder
 import io.matthewnelson.kmp.process.internal.appendProcessInfo
 import io.matthewnelson.kmp.process.internal.commonWaitFor
@@ -42,6 +43,9 @@ public abstract class Process internal constructor(
     public val stdio: Stdio.Config,
     @JvmField
     public val destroySignal: Signal,
+
+    @Suppress("UNUSED_PARAMETER")
+    lock: SyntheticAccess
 ): OutputFeed.Handler(stdio) {
 
     /**

--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Process.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Process.kt
@@ -44,8 +44,7 @@ public abstract class Process internal constructor(
     @JvmField
     public val destroySignal: Signal,
 
-    @Suppress("UNUSED_PARAMETER")
-    lock: SyntheticAccess
+    init: SyntheticAccess
 ): OutputFeed.Handler(stdio) {
 
     /**
@@ -387,5 +386,9 @@ public abstract class Process internal constructor(
             stdio,
             destroySignal
         )
+    }
+
+    init {
+        check(init == SyntheticAccess.get()) { "Process cannot be extended. Use Process.Builder" }
     }
 }

--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/SyntheticAccess.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/SyntheticAccess.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.process.internal
+
+import kotlin.jvm.JvmSynthetic
+
+// Because Process is an abstract class, it
+// could be extended from Java land as the
+// internal constructor compiles to public.
+//
+// This is an "attempt" to inhibit Java only
+// consumers from being able to extend Process
+// as the only way to obtain is through
+// synthetic access via get().
+internal class SyntheticAccess private constructor() {
+
+    internal companion object {
+
+        private val instance = SyntheticAccess()
+
+        @JvmSynthetic
+        internal fun get(): SyntheticAccess = instance
+    }
+}

--- a/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/NodeJsProcess.kt
+++ b/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/NodeJsProcess.kt
@@ -29,7 +29,7 @@ internal class NodeJsProcess internal constructor(
     env: Map<String, String>,
     stdio: Stdio.Config,
     destroy: Signal,
-): Process(command, args, env, stdio, destroy) {
+): Process(command, args, env, stdio, destroy, SyntheticAccess.get()) {
 
     override fun destroy(): Process {
         isDestroyed = true

--- a/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/JvmProcess.kt
+++ b/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/JvmProcess.kt
@@ -21,7 +21,6 @@ import io.matthewnelson.kmp.process.Signal
 import io.matthewnelson.kmp.process.Stdio
 import java.io.InputStream
 import java.util.Scanner
-import java.util.concurrent.Executors
 import kotlin.time.Duration
 
 internal class JvmProcess private constructor(
@@ -59,16 +58,6 @@ internal class JvmProcess private constructor(
         -1
     }
 
-    private val executors = numStdioOutputThreads()?.let { numThreads ->
-        Instance(create = {
-            if (isDestroyed) return@Instance null
-
-            Executors.newFixedThreadPool(numThreads) { runnable ->
-                Thread(runnable).apply { isDaemon = true }
-            }
-        })
-    }
-
     override fun destroy(): Process {
         isDestroyed = true
 
@@ -76,8 +65,6 @@ internal class JvmProcess private constructor(
             Signal.SIGTERM -> jProcess.destroy()
             Signal.SIGKILL -> jProcess.destroyForcibly()
         }
-
-        executors?.getOrNull()?.shutdown()
 
         return this
     }
@@ -121,22 +108,29 @@ internal class JvmProcess private constructor(
     @Throws(InterruptedException::class)
     override fun waitFor(duration: Duration): Int? = commonWaitFor(duration) { it.threadSleep() }
 
-    protected override fun startStdout() {
-        val executors = executors?.getOrCreate() ?: return
-        executors.execute(Eater(
+    override fun startStdout() {
+        StreamEater(
             jProcess.inputStream,
             ::dispatchStdout,
-            ::onStdoutStopped
-        ))
+            ::onStdoutStopped,
+        ).start("stdout")
     }
 
-    protected override fun startStderr() {
-        val executors = executors?.getOrCreate() ?: return
-        executors.execute(Eater(
+    override fun startStderr() {
+        StreamEater(
             jProcess.errorStream,
             ::dispatchStderr,
-            ::onStderrStopped
-        ))
+            ::onStderrStopped,
+        ).start("stderr")
+    }
+
+    @Suppress("NOTHING_TO_INLINE")
+    private inline fun StreamEater.start(name: String) {
+        val t = Thread(this, "Process[pid=$_pid, stdio=$name]")
+        t.isDaemon = true
+        try {
+            t.start()
+        } catch (_: IllegalThreadStateException) {}
     }
 
     internal companion object {
@@ -159,20 +153,10 @@ internal class JvmProcess private constructor(
         )
     }
 
-    @Suppress("NOTHING_TO_INLINE")
-    private inline fun numStdioOutputThreads(): Int? {
-        var num = 0
-        if (stdio.stdout is Stdio.Pipe) num++
-        if (stdio.stderr is Stdio.Pipe) num++
-
-        if (num == 0) return null
-        return num
-    }
-
-    private inner class Eater(
+    private class StreamEater(
         stream: InputStream,
         private val dispatch: (line: String) -> Unit,
-        private val stopped: () -> Unit,
+        private val onStopped: () -> Unit,
     ): Runnable {
 
         private val scanner = Scanner(stream.bufferedReader())
@@ -182,7 +166,7 @@ internal class JvmProcess private constructor(
                 val line = scanner.nextLine()
                 dispatch(line)
             }
-            stopped()
+            onStopped()
         }
     }
 }

--- a/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/JvmProcess.kt
+++ b/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/JvmProcess.kt
@@ -30,7 +30,7 @@ internal class JvmProcess private constructor(
     env: Map<String, String>,
     stdio: Stdio.Config,
     destroy: Signal,
-): Process(command, args, env, stdio, destroy) {
+): Process(command, args, env, stdio, destroy, SyntheticAccess.get()) {
 
     private val _pid: Int by lazy {
         // First try parsing toString output

--- a/library/process/src/nativeMain/kotlin/io/matthewnelson/kmp/process/internal/NativeProcess.kt
+++ b/library/process/src/nativeMain/kotlin/io/matthewnelson/kmp/process/internal/NativeProcess.kt
@@ -33,7 +33,7 @@ internal constructor(
     env: Map<String, String>,
     stdio: Stdio.Config,
     destroy: Signal,
-): Process(command, args, env, stdio, destroy) {
+): Process(command, args, env, stdio, destroy, SyntheticAccess.get()) {
 
     init {
         if (pid <= 0) {

--- a/library/process/src/nativeMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/nativeMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -71,7 +71,7 @@ internal actual class PlatformBuilder private actual constructor() {
             return p
         } catch (e: UnsupportedOperationException) {
             // should never be the case, but have to handle.
-            throw e.wrapIOException { "Neither posix_spawn or fork/exec are supported" }
+            throw IOException("Neither posix_spawn or fork/exec are supported", e)
         }
     }
 

--- a/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/UnixPlatform.kt
+++ b/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/UnixPlatform.kt
@@ -39,7 +39,6 @@ internal actual fun MemScope.posixSpawn(
     destroy: Signal,
 ): NativeProcess {
     val fileActions = posixSpawnFileActionsInit()
-    val attrs = posixSpawnAttrInit()
 
     // TODO: try chg dir first
     //  - Linux glibc < 2.24 throw UnsupportedOperationException
@@ -47,6 +46,8 @@ internal actual fun MemScope.posixSpawn(
     //  - iOS throw IOException (it's not supported, but we want
     //    to stop early w/o trying fork & exec b/c that is not
     //    supported on iOS either.
+
+    val attrs = posixSpawnAttrInit()
 
     // TODO: streams Issue #2
 


### PR DESCRIPTION
This PR cleans up the `Jvm` implementation by:
 - Removing use of `ExecutorService` from `JvmProcess` in favor of using `Thread`
 - Adding synthetic only access to `Process` constructor to inhibit Java consumers from being able to extend it