### PR TITLE
Fix unix `forkExec` error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![badge-latest-release]][url-latest-release]
 
 [![badge-kotlin]][url-kotlin]
-[![badge-kmp-file]][url-kmp-file]
+[![badge-endians]][url-endians]
 [![badge-immutable]][url-immutable]
+[![badge-kmp-file]][url-kmp-file]
 
 ![badge-platform-android]
 ![badge-platform-jvm]
@@ -155,6 +156,7 @@ dependencies {
 [badge-license]: https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat
 
 <!-- TAG_DEPENDENCIES -->
+[badge-endians]: https://img.shields.io/badge/kotlincrypto.endians-0.2.0-blue.svg?style=flat
 [badge-immutable]: https://img.shields.io/badge/immutable-0.1.0-blue.svg?style=flat
 [badge-kmp-file]: https://img.shields.io/badge/kmp--file-0.1.0--beta01-blue.svg?style=flat
 [badge-kotlin]: https://img.shields.io/badge/kotlin-1.9.22-blue.svg?logo=kotlin
@@ -178,6 +180,7 @@ dependencies {
 
 [url-latest-release]: https://github.com/05nelsonm/kmp-process/releases/latest
 [url-license]: https://www.apache.org/licenses/LICENSE-2.0
+[url-endians]: https://github.com/KotlinCrypto/endians
 [url-immutable]: https://github.com/05nelsonm/immutable
 [url-kmp-file]: https://github.com/05nelsonm/kmp-file
 [url-kotlin]: https://kotlinlang.org

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ immutable = "0.1.0"
 
 kmp-file = "0.1.0-beta01"
 kmp-tor-resource = "408.10.0-SNAPSHOT"
+kotlincrypto-endians = "0.2.0"
 kotlinx-coroutines = "1.7.3"
 
 [libraries]
@@ -27,6 +28,7 @@ immutable-collections = { module = "io.matthewnelson.immutable:collections", ver
 
 kmp-file = { module = "io.matthewnelson.kmp-file:file", version.ref = "kmp-file" }
 kmp-tor-resource-tor = { module = "io.matthewnelson.kmp-tor:resource-tor", version.ref = "kmp-tor-resource" }
+kotlincrypto-endians = { module = "org.kotlincrypto.endians:endians", version.ref = "kotlincrypto-endians" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 [plugins]

--- a/library/process/build.gradle.kts
+++ b/library/process/build.gradle.kts
@@ -43,8 +43,15 @@ kmpConfiguration {
 
         kotlin {
             with(sourceSets) {
+                findByName("unixMain")?.apply {
+                    dependencies {
+                        implementation(libs.kotlincrypto.endians)
+                    }
+                }
+
                 val jvmMain = findByName("jvmMain")
                 val nativeMain = findByName("nativeMain")
+
                 if (nativeMain != null || jvmMain != null) {
                     val nonJsMain = maybeCreate("nonJsMain")
                     nonJsMain.dependsOn(getByName("commonMain"))

--- a/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -232,6 +232,7 @@ internal actual class PlatformBuilder private actual constructor() {
             try {
                 StdioWriter(pipe).write(b)
             } finally {
+                handle.close()
                 close(pipe.fdWrite)
             }
             _exit(1)

--- a/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -166,7 +166,12 @@ internal actual class PlatformBuilder private actual constructor() {
         handle: StdioHandle,
         destroy: Signal,
     ): NativeProcess {
-        val pipe = Stdio.Pipe.fdOpen()
+        val pipe = try {
+            Stdio.Pipe.fdOpen()
+        } catch (e: IOException) {
+            handle.close()
+            throw e
+        }
 
         val pid = try {
             fork().check()

--- a/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -201,7 +201,7 @@ internal actual class PlatformBuilder private actual constructor() {
                 // [#, #, #, #, 1] (1: dup2 failure)
                 val b = ByteArray(5)
                 b[4] = 1
-                (err ?: EBADFD).toBigEndian().copyInto(b)
+                (err ?: EBADF).toBigEndian().copyInto(b)
                 try {
                     StdioWriter(pipe).write(b)
                 } finally {

--- a/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -29,9 +29,14 @@ import io.matthewnelson.kmp.process.internal.spawn.GnuLibcVersion
 import io.matthewnelson.kmp.process.internal.spawn.PosixSpawnAttrs.Companion.posixSpawnAttrInit
 import io.matthewnelson.kmp.process.internal.spawn.PosixSpawnFileActions.Companion.posixSpawnFileActionsInit
 import io.matthewnelson.kmp.process.internal.spawn.posixSpawn
+import io.matthewnelson.kmp.process.internal.stdio.StdioDescriptor.Pair.Companion.fdOpen
 import io.matthewnelson.kmp.process.internal.stdio.StdioHandle
 import io.matthewnelson.kmp.process.internal.stdio.StdioHandle.Companion.openHandle
+import io.matthewnelson.kmp.process.internal.stdio.StdioReader
+import io.matthewnelson.kmp.process.internal.stdio.StdioWriter
 import kotlinx.cinterop.*
+import org.kotlincrypto.endians.BigEndian
+import org.kotlincrypto.endians.BigEndian.Companion.toBigEndian
 import platform.posix.*
 
 // unixMain
@@ -161,32 +166,76 @@ internal actual class PlatformBuilder private actual constructor() {
         handle: StdioHandle,
         destroy: Signal,
     ): NativeProcess {
-        val pid = fork().check()
+        val pipe = Stdio.Pipe.fdOpen()
+
+        val pid = try {
+            fork().check()
+        } catch (e: IOException) {
+            handle.close()
+            pipe.close()
+            throw e
+        }
 
         if (pid == 0) {
+            // Child process
+            close(pipe.fdRead)
+
+            var err: Int? = null
+
             try {
                 handle.dup2 { fd, newFd ->
                     when (dup2(fd, newFd)) {
-                        -1 -> errnoToIOException(errno)
+                        -1 -> {
+                            err = errno
+                            // thrown (and handle is thus closed)
+                            // but catch block from within the child
+                            // does not utilize the exception, it
+                            // will write errno output back to
+                            // parent.
+                            IOException()
+                        }
                         else -> null
                     }
                 }
             } catch (_: IOException) {
-                // TODO: Handle error better
+                // [#, #, #, #, 1] (1: dup2 failure)
+                val b = ByteArray(5)
+                b[4] = 1
+                (err ?: EBADFD).toBigEndian().copyInto(b)
+                try {
+                    StdioWriter(pipe).write(b)
+                } finally {
+                    close(pipe.fdWrite)
+                }
                 _exit(1)
             }
 
-            memScoped {
+            val errno = memScoped {
                 val argv = args.toArgv(program = program, scope = this)
                 val envp = env.toEnvp(scope = this)
 
                 execve(program.path, argv, envp)
-                // TODO: Handle error better
-                _exit(errno)
+
+                // exec failed to replace child process with program
+                errno
             }
+
+            // [#, #, #, #, 2] (2: execve failure)
+            val b = ByteArray(5)
+            b[4] = 2
+            errno.toBigEndian().copyInto(b)
+            try {
+                StdioWriter(pipe).write(b)
+            } finally {
+                close(pipe.fdWrite)
+            }
+            _exit(1)
         }
 
-        return NativeProcess(
+        // Parent process
+        close(pipe.fdWrite)
+
+        val p = NativeProcess(
             pid,
             handle,
             command,
@@ -194,6 +243,49 @@ internal actual class PlatformBuilder private actual constructor() {
             env,
             destroy,
         )
+
+        // Below is "sort of" like vfork on Linux, but
+        // with error validation and cleanup on our end.
+        val b = ByteArray(5)
+
+        val read = try {
+            StdioReader(pipe).read(b)
+        } catch (e: IOException) {
+            p.destroy()
+            throw IOException("CLOEXEC pipe read failure", e)
+        } finally {
+            close(pipe.fdRead)
+        }
+
+        var err: IOException? = null
+
+        when (read) {
+            0 -> { /* execve successful */ }
+            b.size -> {
+                val type = when (b[4].toInt()) {
+                    1 -> "dup2"
+                    2 -> "exec"
+                    else -> null
+                }
+
+                err = if (type == null) {
+                    IOException("CLOEXEC pipe validation check failure")
+                } else {
+                    val errno = BigEndian(b[0], b[1], b[2], b[3]).toInt()
+                    val msg = strerror(errno)?.toKString() ?: "errno: $errno"
+                    IOException("Child process $type failure. $msg")
+                }
+            }
+            -1 -> err = errnoToIOException(errno)
+            else -> err = IOException("invalid read on CLOEXEC pipe")
+        }
+
+        err?.let { ex ->
+            p.destroy()
+            throw ex
+        }
+
+        return p
     }
 
     internal actual companion object {

--- a/library/process/src/unixTest/kotlin/io/matthewnelson/kmp/process/internal/ForkUnitTest.kt
+++ b/library/process/src/unixTest/kotlin/io/matthewnelson/kmp/process/internal/ForkUnitTest.kt
@@ -19,9 +19,12 @@ import io.matthewnelson.kmp.file.IOException
 import io.matthewnelson.kmp.process.IsDarwinMobile
 import io.matthewnelson.kmp.process.Signal
 import io.matthewnelson.kmp.process.Stdio
+import io.matthewnelson.kmp.process.internal.stdio.StdioHandle
 import io.matthewnelson.kmp.process.internal.stdio.StdioHandle.Companion.openHandle
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
 
 class ForkUnitTest {
 
@@ -32,7 +35,7 @@ class ForkUnitTest {
             return
         }
 
-        val p = forkProcess("sh", listOf("-c", "sleep 1; exit 42;"))
+        val p = forkProcess("sh", listOf("-c", "sleep 1; exit 42"))
         val code = try {
             p.waitFor()
         } finally {
@@ -43,19 +46,59 @@ class ForkUnitTest {
         assertEquals(42, code)
     }
 
+    @Test
+    fun givenInvalidProgramPath_whenFork_thenExecThrowsException() {
+        if (IsDarwinMobile) {
+            println("Skipping...")
+            return
+        }
+
+        try {
+            // Should result in an ENOENT when exec is called
+            val p = forkProcess("/invalid/path/sh", listOf("-c", "sleep 1; exit 5"))
+            p.destroy()
+            fail("forkExec returned Process")
+        } catch (e: IOException) {
+            assertTrue(e.message!!.startsWith("Child process exec failure."))
+        }
+    }
+
+    @Test
+    fun givenBadDup2_whenFork_thenDup2ThrowsException() {
+        if (IsDarwinMobile) {
+            println("Skipping...")
+            return
+        }
+
+        try {
+            val h = Stdio.Config.Builder.get().build(null).openHandle()
+
+            // This should result in an IOException when dup2 is called in child process
+            // which will then be piped back to the parent process and child _exit called
+            h.close()
+
+            val p = forkProcess("sh", listOf("-c", "sleep 1; exit 5"), h)
+            p.destroy()
+            fail("forkExec returned Process")
+        } catch (e: IOException) {
+            assertTrue(e.message!!.startsWith("Child process dup2 failure."))
+        }
+    }
+
     private fun forkProcess(
         command: String,
         args: List<String>,
+        handle: StdioHandle? = null,
     ): NativeProcess {
-        val handle = Stdio.Config.Builder.get()
+        val h = handle ?: Stdio.Config.Builder.get()
             .build(null)
             .openHandle()
 
         val p = try {
             val b = PlatformBuilder.get()
-            b.forkExec(command, args, b.env, handle, Signal.SIGTERM)
+            b.forkExec(command, args, b.env, h, Signal.SIGTERM)
         } catch (e: IOException) {
-            handle.close()
+            h.close()
             throw e
         }
 


### PR DESCRIPTION
Adds confirmation of child process viability to `forkExec` before returning a `Process` to the caller.