### PR TITLE
Check `isDestroyed` instead of `handle.isClosed` when terminating `Worker` threads

### DIFF
--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Output.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Output.kt
@@ -109,7 +109,7 @@ public class Output private constructor(
                         if (max < MIN_BUFFER) MIN_BUFFER else max
                     }
                     val timeout = b.timeoutMillis.let { millis ->
-                        (if (millis < MIN_TIMEOUT) MIN_TIMEOUT else millis)
+                        if (millis < MIN_TIMEOUT) MIN_TIMEOUT else millis
                     }
 
                     return Options(maxBuffer, timeout.milliseconds)

--- a/library/process/src/nonJsMain/kotlin/io/matthewnelson/kmp/process/internal/BufferedLineScanner.kt
+++ b/library/process/src/nonJsMain/kotlin/io/matthewnelson/kmp/process/internal/BufferedLineScanner.kt
@@ -66,15 +66,14 @@ internal class BufferedLineScanner private constructor(
             var iNext = 0
             for (i in 0 until read) {
                 if (buf[i] != N) continue
-                val s = overflow.consumeAndJoin(append = buf.decodeToString(iNext, i))
+                val line = overflow.consumeAndJoin(append = buf.decodeToString(iNext, i))
                 iNext = i + 1
 
-                dispatchLine(s)
+                dispatchLine(line)
             }
 
-            if (iNext != read) {
-                overflow.add(buf.copyOfRange(iNext, read))
-            }
+            if (iNext == read) continue
+            overflow.add(buf.copyOfRange(iNext, read))
         }
 
         if (overflow.isNotEmpty()) {


### PR DESCRIPTION
Closes #71 