### PR TITLE
Use `posix_spawnp` when no file system separators present in `command`

### DIFF
--- a/library/process/src/darwinMain/kotlin/io/matthewnelson/kmp/process/internal/spawn/DarwinPosixSpawn.kt
+++ b/library/process/src/darwinMain/kotlin/io/matthewnelson/kmp/process/internal/spawn/DarwinPosixSpawn.kt
@@ -30,3 +30,14 @@ internal actual inline fun MemScope.posixSpawn(
     argv: CValuesRef<CPointerVar<ByteVar>>,
     envp: CValuesRef<CPointerVar<ByteVar>>,
 ): Int = posix_spawn(pid, program, fileActions.ref, attrs.ref, argv, envp)
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(ExperimentalForeignApi::class)
+internal actual inline fun MemScope.posixSpawnP(
+    program: String,
+    pid: CValuesRef<pid_tVar>,
+    fileActions: PosixSpawnFileActions,
+    attrs: PosixSpawnAttrs,
+    argv: CValuesRef<CPointerVar<ByteVar>>,
+    envp: CValuesRef<CPointerVar<ByteVar>>,
+): Int = posix_spawnp(pid, program, fileActions.ref, attrs.ref, argv, envp)

--- a/library/process/src/linuxMain/kotlin/io/matthewnelson/kmp/process/internal/spawn/LinuxPosixSpawn.kt
+++ b/library/process/src/linuxMain/kotlin/io/matthewnelson/kmp/process/internal/spawn/LinuxPosixSpawn.kt
@@ -19,6 +19,7 @@ package io.matthewnelson.kmp.process.internal.spawn
 
 import kotlinx.cinterop.*
 import platform.linux.posix_spawn
+import platform.linux.posix_spawnp
 import platform.posix.pid_tVar
 
 @Suppress("NOTHING_TO_INLINE")
@@ -31,3 +32,14 @@ internal actual inline fun MemScope.posixSpawn(
     argv: CValuesRef<CPointerVar<ByteVar>>,
     envp: CValuesRef<CPointerVar<ByteVar>>,
 ): Int = posix_spawn(pid, program, fileActions.ref, attrs.ref, argv, envp)
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(ExperimentalForeignApi::class)
+internal actual inline fun MemScope.posixSpawnP(
+    program: String,
+    pid: CValuesRef<pid_tVar>,
+    fileActions: PosixSpawnFileActions,
+    attrs: PosixSpawnAttrs,
+    argv: CValuesRef<CPointerVar<ByteVar>>,
+    envp: CValuesRef<CPointerVar<ByteVar>>,
+): Int = posix_spawnp(pid, program, fileActions.ref, attrs.ref, argv, envp)

--- a/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/spawn/UnixPosixSpawn.kt
+++ b/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/spawn/UnixPosixSpawn.kt
@@ -17,13 +17,23 @@
 
 package io.matthewnelson.kmp.process.internal.spawn
 
-import io.matthewnelson.kmp.file.File
 import kotlinx.cinterop.*
 import platform.posix.pid_tVar
 
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(ExperimentalForeignApi::class)
 internal expect inline fun MemScope.posixSpawn(
+    program: String,
+    pid: CValuesRef<pid_tVar>,
+    fileActions: PosixSpawnFileActions,
+    attrs: PosixSpawnAttrs,
+    argv: CValuesRef<CPointerVar<ByteVar>>,
+    envp: CValuesRef<CPointerVar<ByteVar>>,
+): Int
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(ExperimentalForeignApi::class)
+internal expect inline fun MemScope.posixSpawnP(
     program: String,
     pid: CValuesRef<pid_tVar>,
     fileActions: PosixSpawnFileActions,


### PR DESCRIPTION
Closes #105 