### PR TITLE
Fix `NoClassDefFoundException` for Java9+ when module `java.management` is not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ dependencies {
 }
 ```
 
+**NOTE:** For Java9+ consumers, module `java.management` is required. See [issue-139][url-issue-139]
+
 <!-- TAG_VERSION -->
 [badge-latest-release]: https://img.shields.io/badge/latest--release-0.2.0-blue.svg?style=flat
 [badge-license]: https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat
@@ -265,3 +267,4 @@ dependencies {
 [url-posix-fork]: https://man7.org/linux/man-pages/man2/fork.2.html
 [url-posix-spawn]: https://man7.org/linux/man-pages/man3/posix_spawn.3.html
 [url-rust-command]: https://doc.rust-lang.org/std/process/struct.Command.html
+[url-issue-139]: https://github.com/05nelsonm/kmp-process/issues/139

--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Process.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Process.kt
@@ -19,6 +19,7 @@ import io.matthewnelson.immutable.collections.toImmutableList
 import io.matthewnelson.immutable.collections.toImmutableMap
 import io.matthewnelson.kmp.file.*
 import io.matthewnelson.kmp.process.ProcessException.Companion.CTX_DESTROY
+import io.matthewnelson.kmp.process.internal.PID
 import io.matthewnelson.kmp.process.internal.PlatformBuilder
 import io.matthewnelson.kmp.process.internal.SyntheticAccess
 import io.matthewnelson.kmp.process.internal.appendProcessInfo
@@ -113,7 +114,7 @@ public abstract class Process internal constructor(
         public fun environment(): Map<String, String> = PlatformBuilder.get().env.toImmutableMap()
 
         @JvmStatic
-        public fun pid(): Int = PlatformBuilder.myPid()
+        public fun pid(): Int = PID.get()
     }
 
     /**

--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Process.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/Process.kt
@@ -110,9 +110,17 @@ public abstract class Process internal constructor(
      * */
     public object Current {
 
+        /**
+         * Retrieves the current process' environment
+         * */
         @JvmStatic
         public fun environment(): Map<String, String> = PlatformBuilder.get().env.toImmutableMap()
 
+        /**
+         * Retrieves the current process' ID
+         *
+         * @throws [UnsupportedOperationException] if on Java9+ and module 'java.management' is not present.
+         * */
         @JvmStatic
         public fun pid(): Int = PID.get()
     }

--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.process.internal
+
+internal expect object PID {
+    internal fun get(): Int
+}

--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
@@ -18,5 +18,6 @@
 package io.matthewnelson.kmp.process.internal
 
 internal expect object PID {
+    @Throws(UnsupportedOperationException::class)
     internal fun get(): Int
 }

--- a/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/commonMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -48,9 +48,6 @@ internal expect class PlatformBuilder private constructor() {
     ): Process
 
     internal companion object {
-
         internal fun get(): PlatformBuilder
-
-        internal fun myPid(): Int
     }
 }

--- a/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
+++ b/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.process.internal
+
+internal actual object PID {
+    internal actual fun get(): Int = process_pid
+}

--- a/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
+++ b/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
 
 package io.matthewnelson.kmp.process.internal
 
 internal actual object PID {
+//    @Throws(UnsupportedOperationException::class)
     internal actual fun get(): Int = process_pid
 }

--- a/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/jsMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -183,8 +183,6 @@ internal actual class PlatformBuilder private actual constructor() {
 
         internal actual fun get(): PlatformBuilder = PlatformBuilder()
 
-        internal actual fun myPid(): Int = process_pid
-
         private fun Map<String, String>.toJsEnv(): dynamic {
             val jsEnv = js("{}")
             entries.forEach { entry ->

--- a/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
+++ b/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.process.internal
+
+import kotlin.concurrent.Volatile
+
+internal actual object PID {
+
+    @Volatile
+    private var SKIP_JAVA9: Boolean = false
+
+    @JvmSynthetic
+    internal actual fun get(): Int {
+        androidOrNull()?.let { return it }
+
+        if (!SKIP_JAVA9) {
+            // Firstly, check java 9 availability
+            try {
+                java9OrNull()
+            } catch (_: Throwable) {
+                // SecurityException or UnsupportedOperationException
+                null
+            }?.let { return it }
+
+            // Failure. Skip it for successive calls
+            SKIP_JAVA9 = true
+        }
+
+        // Lastly, access java.management module
+        return java10OrNull() ?: java8()
+    }
+
+    @JvmSynthetic
+    internal fun androidOrNull(): Int? {
+        val method = AndroidMyPidMethod ?: return null
+        return method.invoke(null) as Int
+    }
+
+    @JvmSynthetic
+    internal fun java10OrNull(): Int? {
+        val method = RuntimeMXBeanGetPidMethod ?: return null
+        val mxBean = java.lang.management.ManagementFactory
+            .getRuntimeMXBean()
+        return (method.invoke(mxBean) as Long).toInt()
+    }
+
+    @JvmSynthetic
+    @Throws(SecurityException::class, UnsupportedOperationException::class)
+    internal fun java9OrNull(): Int? {
+        val current = ProcessHandleCurrentMethod?.invoke(null) ?: return null
+        val pid = ProcessHandlePidMethod?.invoke(current) ?: return null
+        return (pid as Long).toInt()
+    }
+
+    // Throws NoClassDefFoundError on Android
+    @JvmSynthetic
+    internal fun java8(): Int {
+        return java.lang.management.ManagementFactory
+            .getRuntimeMXBean()
+            .name
+            .split('@')[0]
+            .toInt()
+    }
+
+    // Android
+    private val AndroidMyPidMethod by lazy {
+        if (!IsMobile) return@lazy null
+        Class.forName("android.os.Process")
+            .getMethod("myPid")
+    }
+
+    // Java 9
+    private val ProcessHandleClass by lazy {
+        try {
+            Class.forName("java.lang.ProcessHandle")
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private val ProcessHandlePidMethod by lazy {
+        ProcessHandleClass?.getMethod("pid")
+    }
+
+    private val ProcessHandleCurrentMethod by lazy {
+        ProcessHandleClass?.getMethod("current")
+    }
+
+    // Java 10+
+    private val RuntimeMXBeanGetPidMethod by lazy {
+        try {
+            java.lang.management.RuntimeMXBean::class.java
+                .getMethod("getPid")
+        } catch (_: Throwable) {
+            null
+        }
+    }
+}

--- a/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
+++ b/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
@@ -25,6 +25,7 @@ internal actual object PID {
     private var SKIP_JAVA9: Boolean = false
 
     @JvmSynthetic
+    @Throws(UnsupportedOperationException::class)
     internal actual fun get(): Int {
         androidOrNull()?.let { return it }
 
@@ -42,7 +43,11 @@ internal actual object PID {
         }
 
         // Lastly, access java.management module
-        return java10OrNull() ?: java8()
+        return try {
+            java10OrNull() ?: java8()
+        } catch (t: NoClassDefFoundError) {
+            throw UnsupportedOperationException("Missing access to module java.management", t)
+        }
     }
 
     @JvmSynthetic

--- a/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/jvmMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -149,28 +149,6 @@ internal actual class PlatformBuilder private actual constructor() {
         @JvmSynthetic
         internal actual fun get(): PlatformBuilder = PlatformBuilder()
 
-        @JvmSynthetic
-        internal actual fun myPid(): Int {
-            AndroidMyPidMethod?.let { myPid ->
-                return myPid.invoke(null) as Int
-            }
-
-            return java.lang.management.ManagementFactory
-                .getRuntimeMXBean()
-                .name
-                .split('@')[0]
-                .toInt()
-        }
-
-        private val AndroidMyPidMethod by lazy {
-            // Not Android Runtime
-            if (!IsMobile) return@lazy null
-
-            // Android runtime
-            Class.forName("android.os.Process")
-                .getMethod("myPid")
-        }
-
         @Suppress("NewApi")
         private fun Stdio.toRedirect(
             isStdin: Boolean,

--- a/library/process/src/jvmTest/kotlin/io/matthewnelson/kmp/process/internal/PIDUnitTest.kt
+++ b/library/process/src/jvmTest/kotlin/io/matthewnelson/kmp/process/internal/PIDUnitTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.process.internal
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+// Project requires Java11, so all tests should run properly
+class PIDUnitTest {
+
+    @Test
+    fun givenPID_whenAndroid_thenReturnsNull() {
+        assertNull(PID.androidOrNull())
+    }
+
+    @Test
+    fun givenPID_whenJava9_thenReturnsPIDJava8() {
+        assertEquals(PID.java8(), PID.java9OrNull())
+    }
+
+    @Test
+    fun givenPID_whenJava10_thenReturnsPIDJava8() {
+        assertEquals(PID.java8(), PID.java10OrNull())
+    }
+
+    @Test
+    fun givenPID_whenGet_thenReturnsPIDJava8() {
+        assertEquals(PID.java8(), PID.get())
+    }
+}

--- a/library/process/src/nativeMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
+++ b/library/process/src/nativeMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
@@ -20,5 +20,6 @@ package io.matthewnelson.kmp.process.internal
 import platform.posix.getpid
 
 internal actual object PID {
+    @Throws(UnsupportedOperationException::class)
     internal actual fun get(): Int = getpid()
 }

--- a/library/process/src/nativeMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
+++ b/library/process/src/nativeMain/kotlin/io/matthewnelson/kmp/process/internal/PID.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.process.internal
+
+import platform.posix.getpid
+
+internal actual object PID {
+    internal actual fun get(): Int = getpid()
+}

--- a/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
+++ b/library/process/src/unixMain/kotlin/io/matthewnelson/kmp/process/internal/PlatformBuilder.kt
@@ -380,7 +380,5 @@ internal actual class PlatformBuilder private actual constructor() {
         private const val ERR_EXEC: Byte = 3
 
         internal actual fun get(): PlatformBuilder = PlatformBuilder()
-
-        internal actual fun myPid(): Int = getpid()
     }
 }


### PR DESCRIPTION
Closes #139 