### PR TITLE
Use a `TimeMark` when fulfilling sleep requests greater than `1s`

### DIFF
--- a/library/process/src/blockingMain/kotlin/io/matthewnelson/kmp/process/internal/-BlockingPlatform.kt
+++ b/library/process/src/blockingMain/kotlin/io/matthewnelson/kmp/process/internal/-BlockingPlatform.kt
@@ -21,6 +21,7 @@ import io.matthewnelson.kmp.file.File
 import io.matthewnelson.kmp.file.IOException
 import io.matthewnelson.kmp.file.InterruptedException
 import io.matthewnelson.kmp.file.use
+import io.matthewnelson.kmp.file.wrapIOException
 import io.matthewnelson.kmp.process.*
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -121,7 +122,7 @@ internal fun PlatformBuilder.blockingOutput(
     } catch (_: IllegalStateException) {
         // max buffer exceeded and it hopped out of waitFor
     } catch (e: InterruptedException) {
-        throw IOException("Underlying thread interrupted", e)
+        throw e.wrapIOException { "Underlying thread interrupted" }
     } finally {
         p.destroy()
     }
@@ -133,7 +134,7 @@ internal fun PlatformBuilder.blockingOutput(
             .awaitStop()
             .waitFor()
     } catch (e: InterruptedException) {
-        throw IOException("Underlying thread interrupted", e)
+        throw e.wrapIOException { "Underlying thread interrupted" }
     }
 
     val pErr = when {

--- a/library/process/src/blockingTest/kotlin/io/matthewnelson/kmp/process/BlockingUnitTest.kt
+++ b/library/process/src/blockingTest/kotlin/io/matthewnelson/kmp/process/BlockingUnitTest.kt
@@ -37,8 +37,8 @@ class BlockingUnitTest {
         // Cannot be exact b/c we're talking about threads in a test here,
         // but can be close just to catch any critically wrong function logic.
         val min = duration - 5.milliseconds
-        val max = duration + 50.milliseconds // macOS is ridiculous
-        println("${time.inWholeMilliseconds}ms")
+        val max = duration + 250.milliseconds // macOS is ridiculous
+        println("EXPECTED[${duration.inWholeMilliseconds}ms] vs ACTUAL[${time.inWholeMilliseconds}ms]")
         assertTrue(time in min..max, "${time.inWholeMilliseconds}ms")
     }
 
@@ -56,8 +56,8 @@ class BlockingUnitTest {
         // Cannot be exact b/c we're talking about threads in a test here,
         // but can be close just to catch any critically wrong function logic.
         val min = duration - 5.milliseconds
-        val max = duration + 50.milliseconds // macOS is ridiculous
-        println("${time.inWholeMilliseconds}ms")
+        val max = duration + 250.milliseconds // macOS is ridiculous
+        println("EXPECTED[${duration.inWholeMilliseconds}ms] vs ACTUAL[${time.inWholeMilliseconds}ms]")
         assertTrue(time in min..max, "${time.inWholeMilliseconds}ms")
     }
 


### PR DESCRIPTION
Closes #188 